### PR TITLE
Excludes

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -7,6 +7,7 @@ const fsPromises = fs.promises;
 
 const Target = t.type({
     depends: t.array(t.string),
+    dependsExclude: t.union([t.array(t.string), t.undefined]),
     output: t.string,
     command: t.string,
 });

--- a/findDependencies.ts
+++ b/findDependencies.ts
@@ -12,12 +12,13 @@ const sortedAndUnique = <T>(array: Array<T>): Array<T> => {
     return unique.sort();
 };
 
-export const resolveDependencies = async (dirpath: string, dependencies: Array<string>): Promise<Array<string>> => {
+export const resolveDependencies = async (dirpath: string, dependencies: Array<string>, dependenciesExclude: Array<string>): Promise<Array<string>> => {
     return Promise.all(
         dependencies.map(
             (dependency: string): Promise<Array<string>> => {
                 return globPromise(dependency, {
                     cwd: dirpath,
+                    ignore: dependenciesExclude,
                 });
             },
         ),

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ import { writeManifest } from './writeManifest';
 const execPromise = util.promisify(childProcess.exec);
 
 const runTarget = async (dirpath: string, target: Target): Promise<void> => {
-    const dependsOnFiles = await resolveDependencies(dirpath, target.depends);
+    const dependsOnFiles = await resolveDependencies(dirpath, target.depends, target.dependsExclude || []);
     // console.log('depends', JSON.stringify(dependsOnFiles, null, 2));
     const hashes = await hashDependencies(dirpath, dependsOnFiles);
     // console.log('hashes', JSON.stringify(hashes, null, 2));

--- a/tests/exclude.test.ts
+++ b/tests/exclude.test.ts
@@ -1,0 +1,76 @@
+import * as yaml from 'js-yaml';
+import * as fs from 'fs';
+import * as path from 'path';
+import tmp from 'tmp';
+
+import { run } from '../main';
+
+const fsPromises = fs.promises;
+
+describe('simple', () => {
+    let tmpObj: tmp.DirResult;
+    let tmpDir: string;
+    beforeEach(() => {
+        tmpObj = tmp.dirSync({
+            unsafeCleanup: true,
+        });
+        tmpDir = tmpObj.name;
+
+        fs.writeFileSync(
+            path.join(tmpDir, '.dirbuild.yml'),
+            yaml.safeDump({
+                targets: {
+                    build: {
+                        depends: ['*.txt'],
+                        dependsExclude: ['file2.txt'],
+                        output: './build',
+                        command: 'rm -rf ./build && mkdir build/ && cat file1.txt file2.txt > build/output.txt',
+                    },
+                },
+            }),
+        );
+
+        fs.writeFileSync(path.join(tmpDir, 'file1.txt'), 'file1');
+        fs.writeFileSync(path.join(tmpDir, 'file2.txt'), 'file2');
+    });
+
+    afterEach(() => {
+        if (tmpObj) {
+            tmpObj.removeCallback();
+        }
+    });
+
+    test('changing excluded file does not result in command rerun', async () => {
+        await run(tmpDir, undefined);
+        const outputFilepath = path.join(tmpDir, 'build/output.txt');
+
+        const outputFileStatRun1 = await fsPromises.lstat(outputFilepath);
+
+        // Change an excluded
+        await fsPromises.writeFile(path.join(tmpDir, 'file2.txt'), 'changed file content');
+
+        await run(tmpDir, undefined);
+
+        const outputFileStatRun2 = await fsPromises.lstat(outputFilepath);
+
+        // The modification time for the file should be the same
+        expect(outputFileStatRun1.mtime).toEqual(outputFileStatRun2.mtime);
+    });
+
+    test('changing non excluded file does result in command rerun', async () => {
+        await run(tmpDir, undefined);
+        const outputFilepath = path.join(tmpDir, 'build/output.txt');
+
+        const outputFileStatRun1 = await fsPromises.lstat(outputFilepath);
+
+        // Change a non excluded source file
+        await fsPromises.writeFile(path.join(tmpDir, 'file1.txt'), 'changed file content');
+
+        await run(tmpDir, undefined);
+
+        const outputFileStatRun2 = await fsPromises.lstat(outputFilepath);
+
+        // The modification time for the file should have changed
+        expect(outputFileStatRun1.mtime).not.toEqual(outputFileStatRun2.mtime);
+    });
+});


### PR DESCRIPTION
Can set `dependsExclude` patterns to exclude files that would otherwise be included in `depends`.